### PR TITLE
feat: allow for server islands hydration with `csr=false`

### DIFF
--- a/.changeset/shiny-fireants-flash.md
+++ b/.changeset/shiny-fireants-flash.md
@@ -1,0 +1,5 @@
+---
+'sveltekit-server-islands': minor
+---
+
+feat: allow for server islands hydration with `csr=false`

--- a/README.md
+++ b/README.md
@@ -166,3 +166,13 @@ The `ServerIslandsProps` type will also include another important type: a `fallb
 ```
 
 Note that if you need it you can pass other props to the component (and even update them after the component has been mounted)
+
+## `csr=false` or `csr=true`
+
+This library also works for both client side rendering set to `true` and to `false`. Since setting client side rendering to false will completely prevent svelte components scripts from executing during `build` and `dev` we also generate in the static folder a bundle for your islands.
+
+However if you decide to use `csr=false` there's some gotchas that you should be aware of:
+
+1. Your server islands will not be able to use any sveltekit import like `$app/page`, `$env/static/private` or even `$lib`
+2. While your server islands will be hydrated any other normal component will still have no interactivity
+3. For the above reason any feature that relies on non islands components is not available (like `setContext` and `getContext`)

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
 		}
 	},
 	"peerDependencies": {
-		"svelte": "^5.0.0",
-		"@sveltejs/kit": "^2.0.0"
+		"@sveltejs/kit": "^2.0.0",
+		"svelte": "^5.0.0"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.12",
@@ -64,6 +64,8 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"@types/node": "^22.13.1",
+		"acorn": "^8.14.0",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-plugin-svelte": "^2.46.1",
@@ -76,5 +78,9 @@
 		"typescript": "^5.0.0",
 		"vite": "^6.0.0",
 		"vitest": "^3.0.0"
+	},
+	"dependencies": {
+		"esrap": "^1.4.4",
+		"zimmerframe": "^1.1.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      esrap:
+        specifier: ^1.4.4
+        version: 1.4.4
+      zimmerframe:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.12
@@ -22,16 +29,22 @@ importers:
         version: 1.50.1
       '@sveltejs/adapter-auto':
         specifier: ^4.0.0
-        version: 4.0.0(@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11))
+        version: 4.0.0(@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))
       '@sveltejs/kit':
         specifier: ^2.16.0
-        version: 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11)
+        version: 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))
       '@sveltejs/package':
         specifier: ^2.0.0
         version: 2.3.9(svelte@5.19.6)(typescript@5.7.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.0.3(svelte@5.19.6)(vite@6.0.11)
+        version: 5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))
+      '@types/node':
+        specifier: ^22.13.1
+        version: 22.13.1
+      acorn:
+        specifier: ^8.14.0
+        version: 8.14.0
       eslint:
         specifier: ^9.18.0
         version: 9.19.0
@@ -64,10 +77,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.0.0
-        version: 6.0.11
+        version: 6.0.11(@types/node@22.13.1)
       vitest:
         specifier: ^3.0.0
-        version: 3.0.4
+        version: 3.0.4(@types/node@22.13.1)
 
 packages:
 
@@ -538,6 +551,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@22.13.1':
+    resolution: {integrity: sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==}
+
   '@vitest/expect@3.0.4':
     resolution: {integrity: sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==}
 
@@ -809,8 +825,8 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
-  esrap@1.4.3:
-    resolution: {integrity: sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==}
+  esrap@1.4.4:
+    resolution: {integrity: sha512-tDN6xP/r/b3WmdpWm7LybrD252hY52IokcycPnO+WHfhFF0+n5AWtcLLK7VNV6m0uYgVRhGVs8OkZwRyfC7HzQ==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -1402,6 +1418,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -1915,14 +1934,14 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.0':
     optional: true
 
-  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11))':
+  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))':
     dependencies:
-      '@sveltejs/kit': 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11)
+      '@sveltejs/kit': 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11)':
+  '@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.6)(vite@6.0.11)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -1935,7 +1954,7 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.0
       svelte: 5.19.6
-      vite: 6.0.11
+      vite: 6.0.11(@types/node@22.13.1)
 
   '@sveltejs/package@2.3.9(svelte@5.19.6)(typescript@5.7.3)':
     dependencies:
@@ -1948,25 +1967,25 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.6)(vite@6.0.11)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))
       debug: 4.4.0
       svelte: 5.19.6
-      vite: 6.0.11
+      vite: 6.0.11(@types/node@22.13.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11)':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11))(svelte@5.19.6)(vite@6.0.11)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1)))(svelte@5.19.6)(vite@6.0.11(@types/node@22.13.1))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.19.6
-      vite: 6.0.11
-      vitefu: 1.0.5(vite@6.0.11)
+      vite: 6.0.11(@types/node@22.13.1)
+      vitefu: 1.0.5(vite@6.0.11(@types/node@22.13.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -1978,6 +1997,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@22.13.1':
+    dependencies:
+      undici-types: 6.20.0
+
   '@vitest/expect@3.0.4':
     dependencies:
       '@vitest/spy': 3.0.4
@@ -1985,13 +2008,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.4(vite@6.0.11)':
+  '@vitest/mocker@3.0.4(vite@6.0.11(@types/node@22.13.1))':
     dependencies:
       '@vitest/spy': 3.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11
+      vite: 6.0.11(@types/node@22.13.1)
 
   '@vitest/pretty-format@3.0.4':
     dependencies:
@@ -2277,7 +2300,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@1.4.3:
+  esrap@1.4.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -2771,7 +2794,7 @@ snapshots:
       axobject-query: 4.1.0
       clsx: 2.1.1
       esm-env: 1.2.2
-      esrap: 1.4.3
+      esrap: 1.4.4
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.17
@@ -2807,6 +2830,8 @@ snapshots:
 
   typescript@5.7.3: {}
 
+  undici-types@6.20.0: {}
+
   universalify@0.1.2: {}
 
   uri-js@4.4.1:
@@ -2815,13 +2840,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.0.4:
+  vite-node@3.0.4(@types/node@22.13.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 6.0.11
+      vite: 6.0.11(@types/node@22.13.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2836,22 +2861,23 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.0.11:
+  vite@6.0.11(@types/node@22.13.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.34.0
     optionalDependencies:
+      '@types/node': 22.13.1
       fsevents: 2.3.3
 
-  vitefu@1.0.5(vite@6.0.11):
+  vitefu@1.0.5(vite@6.0.11(@types/node@22.13.1)):
     optionalDependencies:
-      vite: 6.0.11
+      vite: 6.0.11(@types/node@22.13.1)
 
-  vitest@3.0.4:
+  vitest@3.0.4(@types/node@22.13.1):
     dependencies:
       '@vitest/expect': 3.0.4
-      '@vitest/mocker': 3.0.4(vite@6.0.11)
+      '@vitest/mocker': 3.0.4(vite@6.0.11(@types/node@22.13.1))
       '@vitest/pretty-format': 3.0.4
       '@vitest/runner': 3.0.4
       '@vitest/snapshot': 3.0.4
@@ -2867,9 +2893,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11
-      vite-node: 3.0.4
+      vite: 6.0.11(@types/node@22.13.1)
+      vite-node: 3.0.4(@types/node@22.13.1)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.13.1
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,19 +1,21 @@
 import { json } from '@sveltejs/kit';
 import { render } from 'svelte/server';
 
+// import all components in islands as "not-island": this will be the actual component
 const components = /**
  * @type {Record<string, ()=>Promise<{ default: import("svelte").Component, load?: (event: import("@sveltejs/kit").RequestEvent)=>unknown}>>}
  */ (
 	import.meta.glob('/src/islands/*.svelte', {
-		query: '?not-island'
+		query: '?not-island',
 	})
 );
 
+// import all components in islands as "not-island" and raw style: this will be the styles for that component
 const styles = /**
  * @type {Record<string, () => Promise<{ code: string; }>>}
  */ (
 	import.meta.glob('/src/islands/*.svelte', {
-		query: '?raw&svelte&type=style&not-island'
+		query: '?raw&svelte&type=style&not-island',
 	})
 );
 
@@ -36,6 +38,7 @@ const styles = /**
 
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
+	// we create an endpoint to return the server side rendered island
 	if (event.url.pathname === '/__island') {
 		const props = await event.request.json();
 		const name = event.url.searchParams.get('name');
@@ -49,30 +52,30 @@ export async function handle({ event, resolve }) {
 				Object.defineProperty(event.request, 'url', {
 					value: referer,
 					enumerable: true,
-					configurable: true
+					configurable: true,
 				});
 				Object.defineProperty(event, 'url', {
 					value: url,
 					enumerable: true,
-					configurable: true
+					configurable: true,
 				});
 			}
 			Object.defineProperty(event, 'props', {
 				configurable: true,
 				enumerable: true,
-				value: props
+				value: props,
 			});
 			Object.defineProperty(event, 'route', {
 				get() {
 					throw new Error("You can't access the route in a Server Island");
-				}
+				},
 			});
 			props.data = await comp.load(event);
 		}
 		const { body } = render(comp.default, { props });
 		return json({
 			body: `${body}${css.code ? `<style>${css.code}</style>` : ''}`,
-			data: props.data
+			data: props.data,
 		});
 	}
 	return resolve(event);

--- a/src/lib/vite.js
+++ b/src/lib/vite.js
@@ -1,4 +1,118 @@
 /**
+ * @import { ExportNamedDeclaration, Program } from "acorn";
+ */
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { build } from 'vite';
+import { readdir, rm } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { walk } from 'zimmerframe';
+import { print } from 'esrap';
+
+const output_path = '/__islands';
+const output_dir = `static${output_path}`;
+const dir = join(process.cwd(), '/src/islands');
+
+/**
+ * Function used to build the islands components on HMR, on build and on dev...those will be javascript
+ * files imported when the island loads to hydrate even when csr is false
+ */
+async function build_islands() {
+	// remove the old dir
+	await rm(join(process.cwd(), output_dir), { force: true, recursive: true });
+	// read every file in the islands folder
+	const islands_dir = (await readdir(dir, { withFileTypes: true })).filter((file) => file.isFile());
+	const entry = islands_dir.map((file) => file.name);
+	const islands_components = islands_dir.map((file) => join(file.parentPath, file.name));
+	build({
+		plugins: [
+			svelte(),
+			{
+				name: 'vite-plugin-sveltekit-islands-add-hydrate',
+				transform: {
+					order: 'post',
+					handler(code, id) {
+						// we check if this is one of the islands files
+						if (islands_components.includes(id)) {
+							const ast = this.parse(code);
+							// we remove every export named declaration...this has two effects: firstly will treeshake away the load function
+							// allowing the user to use server only code from it without it leaking to the client. Furthermore will allow us
+							// to add an export to hydrate from the module that will be used on the client to hydrate this component if csr is disabled
+							const modified = /** @type {Program} */ (
+								/** @type {unknown} */ (
+									walk(
+										/** @type {ExportNamedDeclaration} */ (/** @type {unknown} */ (ast)),
+										{},
+										{
+											// @ts-ignore
+											ExportNamedDeclaration(node) {
+												// in case there's a declaration we return that declaration...this is to prevent
+												// functions that are exported AND used to be removed completely
+												if (node.declaration) {
+													return node.declaration;
+												}
+												return {
+													type: 'EmptyStatement',
+												};
+											},
+										},
+									)
+								)
+							);
+							// let's push the `export { hydrate } from svelte`
+							modified.body.push({
+								type: 'ExportNamedDeclaration',
+								specifiers: [
+									{
+										type: 'ExportSpecifier',
+										local: {
+											type: 'Identifier',
+											name: 'hydrate',
+											start: 0,
+											end: 0,
+										},
+										exported: {
+											type: 'Identifier',
+											name: 'hydrate',
+											start: 0,
+											end: 0,
+										},
+										start: 0,
+										end: 0,
+									},
+								],
+								source: {
+									type: 'Literal',
+									value: 'svelte',
+									start: 0,
+									end: 0,
+								},
+								attributes: [],
+								start: 0,
+								end: 0,
+							});
+							return print(ast);
+						}
+					},
+				},
+			},
+		],
+		// we only run the build for the specific folder to avoid vite picking up unwanted files
+		root: dir,
+		build: {
+			lib: {
+				formats: ['es'],
+				entry,
+			},
+			rollupOptions: {
+				output: {
+					dir: output_dir,
+				},
+			},
+		},
+	});
+}
+
+/**
  * @returns {import("vite").Plugin}
  */
 export function islands() {
@@ -9,9 +123,27 @@ export function islands() {
 				return 'virtual:render.svelte';
 			}
 		},
+		writeBundle: {
+			sequential: true,
+			handler: () => {
+				// build the islands on build
+				build_islands();
+			},
+		},
+		async configureServer() {
+			// build the islands on dev
+			build_islands();
+		},
+		handleHotUpdate({ file }) {
+			// build the islands on an hot update if the updated file is in islands
+			if (dirname(file) === dir) {
+				build_islands();
+			}
+		},
 		load: {
 			order: 'pre',
 			handler(id) {
+				// companion component to render a snippet in createRawSnippet
 				if (id === 'virtual:render.svelte') {
 					return `<script>
 								let {snippet} =$props();
@@ -27,6 +159,8 @@ export function islands() {
 						!url.searchParams.has('not-island') &&
 						url.searchParams.get('type') !== 'style'
 					) {
+						// this is the "fake component" that we return when the user import the file normally
+						// see how it works in the readme for an explanation of the component
 						return `<script>
 						import Render from 'virtual:render.svelte';
 						import { render } from 'svelte/server';
@@ -53,23 +187,37 @@ export function islands() {
 								}
 							}
 						});
-
 						const code = \`{
 							const island = document.getElementById('\${id}');
+							const props = \${JSON.stringify(all)};
 							let resolve;
 							island.__loaded = new Promise((r)=>{
 								resolve = r;
 							});
-							fetch('__island?name=${name.replace('.svelte', '')}', {
+							const ssr = fetch('__island?name=${name.replace('.svelte', '')}', {
 								method: 'POST',
-								body: '\${JSON.stringify(all)}',
+								body: JSON.stringify(props),
 							}).then((res)=>res.json()).then((html)=>{
 								island.innerHTML = html.body;
 								if(html.data){
 									island.dataset.data = JSON.stringify(html.data);
 								}
 								resolve();
-							});
+								return html.data;
+							})
+
+							const csr_enabled = [...document.querySelectorAll("script")]
+								.findIndex((script_tag)=> script_tag.dataset.island == null && script_tag.innerText.includes('kit.start')) !== -1;
+
+							if(!csr_enabled){
+								ssr.then(async (data)=>{	
+									const { default: comp, hydrate } = await import('${output_path}/${name.replace('.svelte', '.js')}');
+									if(data){
+										props["data"] = data;
+									}
+									hydrate(comp, { target: island, props });
+								});
+							}
 						}\`
 
 						$effect(()=>{
@@ -97,7 +245,7 @@ export function islands() {
 						});
 					</script>
 					{@render is_land(all.fallback)}
-					{@html \`<script>
+					{@html \`<script data-island>
 					\${code}
 					</script>\`}
 					`;
@@ -105,7 +253,7 @@ export function islands() {
 				} catch {
 					/** empty */
 				}
-			}
-		}
+			},
+		},
 	};
 }


### PR DESCRIPTION
This introduces an intermediate build step that will build your islands in their own module that is then served from `static/__islands`. This allow server islands to `hydrate` themselves (we also check the presence of a script tag with the `kit.start` keyword in it to determine if `csr` is enabled or not.